### PR TITLE
Fix some issues in Remote Desktop cases

### DIFF
--- a/PerMonitorDpiBehavior.cs
+++ b/PerMonitorDpiBehavior.cs
@@ -80,6 +80,17 @@ namespace PerMonitorDPI
             if (AssociatedObject.IsInitialized)
             {
                 AddHwndHook();
+                
+                currentDpiRatio = MonitorDpi.GetScaleRatioForWindow(AssociatedObject);
+                
+                if (currentDpiRatio != 1.0)
+                {
+                    //Update Width and Height based on the on the current DPI of the monitor
+                    AssociatedObject.Width = AssociatedObject.Width * currentDpiRatio;
+                    AssociatedObject.Height = AssociatedObject.Height * currentDpiRatio;
+
+                    UpdateDpiScaling(currentDpiRatio);
+                }
             }
             else
             {
@@ -160,8 +171,11 @@ namespace PerMonitorDPI
         {
             currentDpiRatio = newDpiRatio;
 
-            var firstChild = (Visual)VisualTreeHelper.GetChild(AssociatedObject, 0);
-            firstChild.SetValue(Window.LayoutTransformProperty, new ScaleTransform(currentDpiRatio, currentDpiRatio));
+            var content = AssociatedObject.Content as FrameworkElement;
+            if (content != null)
+            {
+                content.LayoutTransform = new ScaleTransform(currentDpiRatio, currentDpiRatio);
+            }
         }
 
     }


### PR DESCRIPTION
Updated OnAttached methods to make sure the UI can be scaled properly when application runs directly on different DPI of monitor(for example, using Surface 3 to remote control a 96 DPI PC and then run the program in remote desktop).

Updated UpdateDpiScaling methods to use another way to scale the UI, this fix issues which can not scale the UI properly when using a high DPI device(e.g. Surface 3) to remote control a low DPI PC which already running the program.
